### PR TITLE
Pass name of the player as argument to formEmptyTeams

### DIFF
--- a/src/cruceGameCurses/cli.c
+++ b/src/cruceGameCurses/cli.c
@@ -225,7 +225,7 @@ void createEmptyTeams(struct Game *game)
 {
     for (int i = 0; i < MAX_GAME_PLAYERS; i++) {
         if (game->players[i] != NULL) {
-            struct Team *team = team_createTeam("NONE");
+            struct Team *team = team_createTeam(game->players[i]->name);
             team_addPlayer(team, game->players[i]);
             game_addTeam(team, game);
         }


### PR DESCRIPTION
Modify the call to formEmptyTeams. Now, the player's name is passed as argument.
