### PR TITLE
Teammates are displayed on the same line - T8.2

### DIFF
--- a/src/cruceGameCurses/cli.c
+++ b/src/cruceGameCurses/cli.c
@@ -364,8 +364,8 @@ int formTeams (struct Game *game)
 
     for (int i = 0; i < 2; i++) {
         struct Team *team = team_createTeam();
-        team_addPlayer(team, game->players[i]);
-        team_addPlayer(team, game->players[i + 1]);
+        team_addPlayer(team, game->players[2 * i]);
+        team_addPlayer(team, game->players[2 * i + 1]);
         game_addTeam(team, game);
     }
 
@@ -555,38 +555,63 @@ int getScoreLimit()
 
     return processingScore(score);
 }
-
 /**
- * @brief Returns the length of the biggest name of a player in a round,
- *      helper for printRoundTerminationMessage.
+ * @brief Computes the size of line in the score dialog. The 
+ *        size of a line consists in the sum of the lengths 
+ *        of the name plus the number of commas and white spaces
+ *        between them. This function is a helper for 
+ *        getBiggestScoreDialogLineSize and printRoundTerminationMessage.
  *
  * @param terminatedRound The round that has just finished. 
+ * @param currentTeam The desired team that size we want to   
+ *        compue.
  *
- * @return The length of the biggest name of a player.
+ * @return int The size of a team. 
  */
-int getBiggestNameSize(struct Round *terminatedRound)
+int getScoreDialogLineSize(struct Team *currentTeam)
 {
-    int maxNameSize = strlen(terminatedRound->players[0]->name);
-    for(int i = 0; i < MAX_GAME_PLAYERS; i++) {
-        if(terminatedRound->players[i] != NULL) {
-            if(strlen(terminatedRound->players[i]->name) > maxNameSize) {
-                maxNameSize = strlen(terminatedRound->players[i]->name);
-            }
-        }
+    int lineSize = 0;
+    int i;
+    for(i = 0; i < MAX_TEAM_PLAYERS; i++) {
+        if(currentTeam->players[i] != NULL)
+            lineSize += strlen(currentTeam->players[i]->name);
     }
-
-    return maxNameSize;
+    lineSize += i + i - 1;
+    return lineSize;
 }
 
-int printRoundTerminationMessage(struct Round *terminatedRound, int *oldScore)
+/**
+ * @brief Get the biggest line's size. This function is a helper for
+ *        printRoundTerminationMessage.
+ *
+ * @param currentGame The game in which these teams reside.
+ *
+ * @return int The size of the biggest line.
+ */
+int getBiggestScoreDialogLineSize(struct Game *currentGame)
 {
-    if(terminatedRound == NULL || terminatedRound->players == NULL)
+    int biggestLineSize = 0;
+    for(int i = 0; i < MAX_GAME_TEAMS; i++) {
+        if(currentGame->teams[i] != NULL) { 
+            int currentLine = getScoreDialogLineSize(currentGame->teams[i]);
+            if(currentLine > biggestLineSize) {
+                biggestLineSize = currentLine;
+              }
+          }
+      }
+
+    return biggestLineSize;
+}
+
+int printRoundTerminationMessage(struct Game *currentGame, int *oldScore)
+{
+    if(currentGame->round == NULL || currentGame->round->players == NULL)
         return ROUND_NULL;
 
     init_pair(2, COLOR_GREEN, COLOR_BLACK);
     init_pair(1, COLOR_RED, COLOR_BLACK);
 
-    int scoreLineSize = getBiggestNameSize(terminatedRound) + 
+    int scoreLineSize = getBiggestScoreDialogLineSize(currentGame) + 
                                            ROUND_DIALOG_SCORE_SIZE;
 
     printw("  _____                       _        _     _ \n"     
@@ -596,22 +621,26 @@ int printRoundTerminationMessage(struct Round *terminatedRound, int *oldScore)
              "  ____) | (_| (_) | | |  __/ | || (_| | |_) | |  __/\n"
             " |_____/ \\___\\___/|_|  \\___|  \\__\\__,_|_.__/|_|\\___|\n\n\n");
 
-    for(int i = 0; i < MAX_GAME_PLAYERS; i++) {
-        if(terminatedRound->players[i] != NULL) {
-            printw("%s", terminatedRound->players[i]->name); 
-            int playersNameWidth = strlen(terminatedRound->players[i]->name);
-
-            int score = terminatedRound->players[i]->score - oldScore[i];         
+    for(int i = 0; i < MAX_GAME_TEAMS; i++) {
+        if(currentGame->teams[i] != NULL) {
+            for(int j = 0; j < 2; j++) {
+                if(currentGame->teams[i]->players[j] != NULL) {
+                   printw("%s%s ", currentGame->teams[i]->players[j]->name, 
+                            ((currentGame->teams[i]->players[j + 1] == NULL) ? "" : ","));
+                }
+            }
+            int currentTeamSize = getScoreDialogLineSize(currentGame->teams[i]);
+            int score = currentGame->teams[i]->score - oldScore[i];         
             int colorPair = (score > 0) ? 2 : 1;
-
             if(score != 0) { 
                 attron(COLOR_PAIR(colorPair));
-                printw("%+*d \n", scoreLineSize - playersNameWidth, score);
+                printw("%*d\n", scoreLineSize - currentTeamSize,
+                        currentGame->teams[i]->score);
                 attroff(COLOR_PAIR(colorPair));
             } else {
-                printw("%*d \n", scoreLineSize - playersNameWidth, score);
+                printw("%*d\n", scoreLineSize - currentTeamSize,
+                         currentGame->teams[i]->score);
             }
-
         }
     }
     return NO_ERROR;

--- a/src/cruceGameCurses/cli.h
+++ b/src/cruceGameCurses/cli.h
@@ -117,10 +117,10 @@ int getScoreLimit();
 /**
  * @brief Prints the score differences between rounds.
  *
- * @param terminatedRound The round that just has finished.
+ * @param currentGame The current game.
  * @param oldScore Old score for every player before the terminated round. 
  *
  * @return int The size of the biggest name of a player in a round.
  */
-int printRoundTerminationMessage(struct Round *terminatedRound, int *oldScore);
+int printRoundTerminationMessage(struct Game *currentGame, int *oldScore);
 

--- a/src/cruceGameCurses/main.c
+++ b/src/cruceGameCurses/main.c
@@ -99,15 +99,15 @@ int main()
         }
         
         int oldScore[MAX_GAME_PLAYERS];
-        for(int i = 0; i < MAX_GAME_PLAYERS; i++) {
-            if(game->round->players[i] != NULL) {
-                oldScore[i] = game->round->players[i]->score;
+        for(int i = 0; i < MAX_GAME_TEAMS; i++) {
+            if(game->teams[i] != NULL) {
+                oldScore[i] = game->teams[i]->score;
             }
         }
 
         game_updateScore(game, bidWinner);
 
-        printRoundTerminationMessage(game->round, oldScore);
+        printRoundTerminationMessage(game, oldScore);
         getch();
 
         deck_deleteDeck(&deck);


### PR DESCRIPTION
Now, in the score dialog, players that belong to the same team are displayed on the same line. This patch solves T8.2.
